### PR TITLE
Flush logs before each example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Capybara::Chromedriver::Logger::TestHooks.for_rspec!
 
 # Option 2: if you prefer to hook it in manually:
 RSpec.configure do |config|
+  config.before :each, type: :feature do
+    Capybara::Chromedriver::Logger::TestHooks.before_example!
+  end
   config.after :each, type: :feature do
     Capybara::Chromedriver::Logger::TestHooks.after_example!
   end

--- a/lib/capybara/chromedriver/logger/collector.rb
+++ b/lib/capybara/chromedriver/logger/collector.rb
@@ -17,18 +17,6 @@ module Capybara
           clear_errors!
         end
 
-        private
-
-        def raise_errors_if_needed!
-          return unless Capybara::Chromedriver::Logger.raise_js_errors?
-          return if errors.empty?
-
-          formatted_errors = errors.map(&:to_s)
-          error_list = formatted_errors.join("\n")
-
-          raise JsError, "Got some JS errors during testing:\n\n#{error_list}"
-        end
-
         def flush_logs!
           browser_logs.each do |log|
             message = Message.new(log)
@@ -39,6 +27,18 @@ module Capybara
             
             log_destination.puts message.to_s
           end
+        end
+
+        private
+
+        def raise_errors_if_needed!
+          return unless Capybara::Chromedriver::Logger.raise_js_errors?
+          return if errors.empty?
+
+          formatted_errors = errors.map(&:to_s)
+          error_list = formatted_errors.join("\n")
+
+          raise JsError, "Got some JS errors during testing:\n\n#{error_list}"
         end
 
         def clear_errors!

--- a/lib/capybara/chromedriver/logger/test_hooks.rb
+++ b/lib/capybara/chromedriver/logger/test_hooks.rb
@@ -2,6 +2,11 @@ module Capybara
   module Chromedriver
     module Logger
       class TestHooks
+        def self.before_example!
+          collector = Capybara::Chromedriver::Logger::Collector.new
+          collector.flush_logs!
+        end
+
         def self.after_example!
           collector = Capybara::Chromedriver::Logger::Collector.new
           collector.flush_and_check_errors!
@@ -10,6 +15,9 @@ module Capybara
         def self.for_rspec!
           ::RSpec.configure do |config|
             %i[feature system].each do |type|
+              config.before :each, type: type do
+                Capybara::Chromedriver::Logger::TestHooks.before_example!
+              end
               config.after :each, type: type do
                 Capybara::Chromedriver::Logger::TestHooks.after_example!
               end


### PR DESCRIPTION
It is possible to have logging after the `after` hooks, which then leak into the following example. Wiping the logs before the example prevents this leakage.

This is the cause of a few flaky specs in Up. Namely, all the ones in `api/spec/end_to_end/admin/account_owner_risk_spec.rb`.